### PR TITLE
Bump library versions

### DIFF
--- a/ILovePDF/ILovePDF/ILovePDF.csproj
+++ b/ILovePDF/ILovePDF/ILovePDF.csproj
@@ -1,69 +1,72 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
-    <RootNamespace>LovePdf</RootNamespace>
-    <AssemblyName>ILovePdf</AssemblyName>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net45;net46;</TargetFrameworks>
-	<LangVersion>10.0</LangVersion>
-    <AssemblyTitle>iLovePDF</AssemblyTitle>
-    <Product>iLovePDF</Product>
-    <Description>Develop and automate PDF processing tasks like Compress PDF, Merge PDF, Split PDF, convert Office to PDF, PDF to JPG, Images to PDF, add Page Numbers, Rotate PDF, Unlock PDF, stamp a Watermark and Repair PDF. Each one with several settings to get your desired results.</Description>
-    <Copyright>Copyright 2017-2020</Copyright>
-    <Version>1.3.3</Version>
-    <AssemblyVersion>1.3.3.0</AssemblyVersion>
-    <FileVersion>1.3.3.0</FileVersion>
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <Authors>Mario Martinez, Alexandra Kyluk, Aleksey Sidorov, Egor Krivoshapka</Authors>
-    <PackageId>ILove_PDF</PackageId>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/ilovepdf/ilovepdf-net</PackageProjectUrl>
-    <PackageReleaseNotes>- Fixed problem (finally) with the missed JWT expiration time checking.</PackageReleaseNotes>
-    <PackageTags>ILOVEPDF Merge PDF Split convert Office to pdf PDf JPG Images unlock Pdf repair rotate pdf</PackageTags>
-	<AnalysisMode>AllEnabledByDefault</AnalysisMode>
-	<AnalysisLevel>latest</AnalysisLevel>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>full</DebugType>
-    <DocumentationFile>bin\$(Configuration)\ILovePdf.xml</DocumentationFile>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>iLovePdf.snk</AssemblyOriginatorKeyFile>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-  </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="jose-jwt" Version="2.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+		<RootNamespace>LovePdf</RootNamespace>
+		<AssemblyName>ILovePdf</AssemblyName>
+		<TargetFrameworks>netstandard1.5;netstandard2.0;net45;net46;net6.0;</TargetFrameworks>
+		<LangVersion>9.0</LangVersion>
+		<AssemblyTitle>iLovePDF</AssemblyTitle>
+		<Product>iLovePDF</Product>
+		<Description>Develop and automate PDF processing tasks like Compress PDF, Merge PDF, Split PDF, convert Office to PDF, PDF to JPG, Images to PDF, add Page Numbers, Rotate PDF, Unlock PDF, stamp a Watermark and Repair PDF. Each one with several settings to get your desired results.</Description>
+		<Copyright>Copyright 2017-2022</Copyright>
+		<Version>1.3.3</Version>
+		<AssemblyVersion>1.3.3.0</AssemblyVersion>
+		<FileVersion>1.3.3.0</FileVersion>
+		<OutputPath>bin\$(Configuration)\</OutputPath>
+		<Authors>Mario Martinez, Alexandra Kyluk, Aleksey Sidorov, Egor Krivoshapka</Authors>
+		<PackageId>ILove_PDF</PackageId>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/ilovepdf/ilovepdf-net</PackageProjectUrl>
+		<PackageReleaseNotes>- Fixed problem (finally) with the missed JWT expiration time checking.</PackageReleaseNotes>
+		<PackageTags>ILOVEPDF Merge PDF Split convert Office to pdf PDf JPG Images unlock Pdf repair rotate pdf</PackageTags>
+		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<AnalysisLevel>latest</AnalysisLevel>
+	</PropertyGroup>
 
-  <ItemGroup Condition="('$(TargetFramework)' == 'net45') Or ('$(TargetFramework)' == 'net46')">
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DebugType>full</DebugType>
+		<DocumentationFile>bin\$(Configuration)\ILovePdf.xml</DocumentationFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\.editorconfig" Link=".editorconfig" />
-    <None Include="iLovePdf.snk" />
-  </ItemGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>pdbonly</DebugType>
+	</PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <PackageReference Include="System.Diagnostics.FileVersionInfo">
-      <Version>4.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Net.Security">
-      <Version>4.3.2</Version>
-    </PackageReference>
-  </ItemGroup>
-  
+	<PropertyGroup>
+		<AssemblyOriginatorKeyFile>iLovePdf.snk</AssemblyOriginatorKeyFile>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="jose-jwt" Version="4.0.1" />
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\.editorconfig" Link=".editorconfig" />
+		<None Include="iLovePdf.snk" />
+	</ItemGroup>
+
+	<ItemGroup Condition="('$(TargetFramework)' == 'net45') or '$(TargetFramework)' == 'net46'">
+		<Reference Include="System.Net.Http" />
+	</ItemGroup>
+	
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
+		<PackageReference Include="System.Diagnostics.FileVersionInfo">
+			<Version>4.3.0</Version>
+		</PackageReference>
+		<PackageReference Include="System.Net.Security">
+			<Version>4.3.2</Version>
+		</PackageReference>
+	</ItemGroup> 
 </Project>

--- a/ILovePDF/Samples/Samples.csproj
+++ b/ILovePDF/Samples/Samples.csproj
@@ -2,12 +2,10 @@
   <PropertyGroup>
     <ProjectGuid>{652B4674-62CF-46A2-9FDF-F1D342FC79A5}</ProjectGuid>
     <TargetFramework>net46</TargetFramework>
+	<LangVersion>9.0</LangVersion>
     <AssemblyTitle>Samples</AssemblyTitle>
     <Product>Samples</Product>
-    <Copyright>Copyright ©  2017</Copyright>
-    <AssemblyTitle>Samples</AssemblyTitle>
-    <Product>Samples</Product>
-    <Copyright>Copyright ©  2017</Copyright>
+    <Copyright>Copyright ©  2017</Copyright> 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>

--- a/ILovePDF/Tests/Tests.csproj
+++ b/ILovePDF/Tests/Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{76837053-65FD-43F0-B69D-1C6965B302E2}</ProjectGuid>
     <TargetFramework>net46</TargetFramework>
+	<LangVersion>9.0</LangVersion>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
@@ -23,9 +24,7 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
-  <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
+  <ItemGroup> 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />


### PR DESCRIPTION
- Added .NET 6
- Added NET Framework 4.5 support library (https://stackoverflow.com/questions/70022194/open-net-framework-4-5-project-in-vs-2022-is-there-any-workaround)
- Setted C# language version to 9.0