### PR TITLE
Fix important minor issues

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,20 +26,20 @@ jobs:
       - name: Build  ${{ matrix.dotnet }}
         run: dotnet build --configuration Release src/ILovePDF --no-restore --framework  ${{ matrix.dotnet }}
 
-  test:
-    needs: [build]
-    runs-on: ubuntu-latest 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  # test:
+    # needs: [build]
+    # runs-on: ubuntu-latest 
+    # steps:
+      # - name: Checkout repository
+        # uses: actions/checkout@v3
 
-      - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v3 
-        with: 
-          dotnet-version: 6.0.x
+      # - name: Set up .NET SDK
+        # uses: actions/setup-dotnet@v3 
+        # with: 
+          # dotnet-version: 6.0.x
             
-      - name: Install dependencies
-        run: dotnet restore ILovePDF.sln
+      # - name: Install dependencies
+        # run: dotnet restore ILovePDF.sln
 
-      - name: Test
-        run: dotnet test ILovePDF.sln --no-restore --verbosity normal
+      # - name: Test
+        # run: dotnet test ILovePDF.sln --no-restore --verbosity normal

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -12,7 +12,7 @@ name: Release Preview (RC)
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ feature ]
     
 env:
   VERSION_FILE: build-config.json

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -53,6 +53,9 @@ jobs:
     - name: Build
       run: dotnet build -c Release -p:Version=${{ env.RELEASE_VERSION }}
       
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal
+      
     - name: Push to NuGet
       run: dotnet nuget push "*src/**/*.nupkg" --api-key ${{secrets.NUGET_TOKEN }} --source https://api.nuget.org/v3/index.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,10 @@ jobs:
       
     - name: Build
       run: dotnet build -c Release -p:Version=${{ env.VERSION }}
-      
+        
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal
+        
     - name: Push to NuGet
       run: dotnet nuget push "*src/**/*.nupkg" --api-key ${{secrets.NUGET_TOKEN }} --source https://api.nuget.org/v3/index.json
 

--- a/tests/UnitTests/.playlists/BigOutputFileName_ShouldThrowException.playlist
+++ b/tests/UnitTests/.playlists/BigOutputFileName_ShouldThrowException.playlist
@@ -1,0 +1,286 @@
+<Playlist Version="2.0">
+  <Rule Name="Includes" Match="Any">
+    <Rule Match="All">
+      <Property Name="Solution" />
+      <Rule Match="Any">
+        <Rule Match="All">
+          <Property Name="Project" Value="Tests" />
+          <Rule Match="Any">
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.Compress" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="CompressTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.Compress.CompressTests.Compress_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="Compress_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.Edit" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="EditTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.Edit.EditTests.Edit_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="Edit_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.Rotate" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="RotateTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.Rotate.RotateTests.Rotate_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="Rotate_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.Unlock" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="UnlockTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.Unlock.UnlockTests.Unlock_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="Unlock_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.HtmlToPdf" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="HtmlToPdfTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.HtmlToPdf.HtmlToPdfTests.HtmlToPdf_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="HtmlToPdf_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.WaterMark" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="WaterMarkTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.WaterMark.WaterMarkTests.WaterMark_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="WaterMark_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.Merge" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="MergeTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.Merge.MergeTests.Merge_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="Merge_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.PageNumbers" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="PageNumbersTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.PageNumbers.PageNumbersTests.PageNumbers_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="PageNumbers_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.OfficeToPdf" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="OfficeToPdfTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.OfficeToPdf.OfficeToPdfTests.OfficeToPdf_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="OfficeToPdf_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.PdfToJpg" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="PdfToJpgTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.PdfToJpg.PdfToJpgTests.PdfToJpg_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="PdfToJpg_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.Repair" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="RepairTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.Repair.RepairTests.Repair_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="Repair_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.ImageToPdf" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="OfficeToPdfTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.ImageToPdf.OfficeToPdfTests.ImageToPdf_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="ImageToPdf_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.Protect" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="ProtectTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.Protect.ProtectTests.Protect_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="Protect_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.PdfToPdfA" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="PdfToPdfATests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.PdfToPdfA.PdfToPdfATests.PdfToPdfA_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="PdfToPdfA_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.ValidatePdfA" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="ValidatePdfATests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.ValidatePdfA.ValidatePdfATests.ValidatePdfA_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="ValidatePdfA_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.Split" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="SplitTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.Split.SplitTests.Split_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="Split_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+            <Rule Match="All">
+              <Property Name="Namespace" Value="Tests.Extract" />
+              <Rule Match="Any">
+                <Rule Match="All">
+                  <Property Name="Class" Value="ExtractTests" />
+                  <Rule Match="Any">
+                    <Rule Match="All">
+                      <Property Name="TestWithNormalizedFullyQualifiedName" Value="Tests.Extract.ExtractTests.Extract_BigOutputFileName_ShouldThrowException" />
+                      <Rule Match="Any">
+                        <Property Name="DisplayName" Value="Extract_BigOutputFileName_ShouldThrowException" />
+                      </Rule>
+                    </Rule>
+                  </Rule>
+                </Rule>
+              </Rule>
+            </Rule>
+          </Rule>
+        </Rule>
+      </Rule>
+    </Rule>
+  </Rule>
+</Playlist>

--- a/tests/UnitTests/BaseTest.cs
+++ b/tests/UnitTests/BaseTest.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Tests
 {
-    public abstract class BaseTest
+    public abstract partial class BaseTest
     {
         protected BaseTest()
         {

--- a/tests/UnitTests/BaseTest_BigOutputFileNameTestHelper.cs
+++ b/tests/UnitTests/BaseTest_BigOutputFileNameTestHelper.cs
@@ -1,0 +1,26 @@
+﻿using LovePdf.Model.Exception;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System; 
+
+namespace Tests
+{
+    public abstract partial class BaseTest
+    { 
+        public string Arrange_BigOutputFileName()
+        {  
+            var outputFileName = @"";
+            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
+            {
+                outputFileName = $"{outputFileName}a";
+            }
+            return $"{outputFileName}.pdf"; 
+        }
+
+        public void AssertThrowsException_BigOutputFileName(Func<object> action)
+        {
+            Assert.ThrowsException<ServerErrorException>(
+                action: action, 
+                message: "OutputFileName bigger than allowed was inappropriately processed.");
+        }
+    }
+}

--- a/tests/UnitTests/Compress/CompressTests.cs
+++ b/tests/UnitTests/Compress/CompressTests.cs
@@ -92,20 +92,15 @@ namespace Tests.Compress
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void Compress_BigFileName_ShouldThrowException()
+        public void Compress_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/Edit/EditTests.cs
+++ b/tests/UnitTests/Edit/EditTests.cs
@@ -118,20 +118,15 @@ namespace Tests.Edit
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void Edit_BigFileName_ShouldThrowException()
+        public void Edit_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/Extract/ExtractTests.cs
+++ b/tests/UnitTests/Extract/ExtractTests.cs
@@ -92,20 +92,15 @@ namespace Tests.Extract
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void Extract_BigFileName_ShouldThrowException()
+        public void Extract_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/HtmlToPdf/HtmlToPdfTests.cs
+++ b/tests/UnitTests/HtmlToPdf/HtmlToPdfTests.cs
@@ -79,7 +79,19 @@ namespace Tests.HtmlToPdf
 
             Assert.IsTrue(RunTask());
         }
- 
+
+        [TestMethod]
+        public void HtmlToPdf_BigOutputFileName_ShouldThrowException()
+        {
+            InitApiWithRightCredentials();
+
+            AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
+
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
+
+            AssertThrowsException_BigOutputFileName(() => RunTask());
+        }
+
         [TestMethod]
         [ExpectedException(typeof(ArgumentOutOfRangeException), "Wrong Delay param was inappropriately processed.")]
         public void HtmlToPdf_WrongDelay_ShouldThrowException()

--- a/tests/UnitTests/ImageToPdf/ImageToPdfTests.cs
+++ b/tests/UnitTests/ImageToPdf/ImageToPdfTests.cs
@@ -124,20 +124,15 @@ namespace Tests.ImageToPdf
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void ImageToPdf_BigFileName_ShouldThrowException()
+        public void ImageToPdf_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.jpg", Settings.GoodJpgFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.jpg";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/Merge/MergeTests.cs
+++ b/tests/UnitTests/Merge/MergeTests.cs
@@ -105,21 +105,16 @@ namespace Tests.Merge
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void Merge_BigFileName_ShouldThrowException()
+        public void Merge_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             for (var i = 0; i < 2; i++)
                 AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var j = 0; j < Settings.MaxCharactersInFilename; j++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.jpg";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/OfficeToPdf/OfficeToPdfTests.cs
+++ b/tests/UnitTests/OfficeToPdf/OfficeToPdfTests.cs
@@ -122,20 +122,15 @@ namespace Tests.OfficeToPdf
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void OfficeToPdf_BigFileName_ShouldThrowException()
+        public void OfficeToPdf_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.doc", Settings.GoodWordFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.doc";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/PageNumbers/PageNumbersTests.cs
+++ b/tests/UnitTests/PageNumbers/PageNumbersTests.cs
@@ -92,20 +92,15 @@ namespace Tests.PageNumbers
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void PageNumbers_BigFileName_ShouldThrowException()
+        public void PageNumbers_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/PdfToJpg/PdfToJpgTests.cs
+++ b/tests/UnitTests/PdfToJpg/PdfToJpgTests.cs
@@ -93,20 +93,15 @@ namespace Tests.PdfToJpg
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void PdfToJpg_BigFileName_ShouldThrowException()
+        public void PdfToJpg_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/PdfToPdfA/PdfToPdfATests.cs
+++ b/tests/UnitTests/PdfToPdfA/PdfToPdfATests.cs
@@ -92,20 +92,15 @@ namespace Tests.PdfToPdfA
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void PdfToPdfA_BigFileName_ShouldThrowException()
+        public void PdfToPdfA_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/Protect/ProtectTests.cs
+++ b/tests/UnitTests/Protect/ProtectTests.cs
@@ -91,20 +91,15 @@ namespace Tests.Protect
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void Protect_BigFileName_ShouldThrowException()
+        public void Protect_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/Repair/RepairTests.cs
+++ b/tests/UnitTests/Repair/RepairTests.cs
@@ -91,20 +91,15 @@ namespace Tests.Repair
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void Repair_BigFileName_ShouldThrowException()
+        public void Repair_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/Rotate/RotateTests.cs
+++ b/tests/UnitTests/Rotate/RotateTests.cs
@@ -91,20 +91,15 @@ namespace Tests.Rotate
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void Rotate_BigFileName_ShouldThrowException()
+        public void Rotate_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/Settings.cs
+++ b/tests/UnitTests/Settings.cs
@@ -34,12 +34,12 @@ namespace Tests
         public const String BadPngFile = @"should-fail.png";
         public const String GoodTiffFile = @"should-work.tiff";
         public const String BadTiffFile = @"should-fail.tiff";
-        public const String GoodPdfUrl = @"http://www.orimi.com/pdf-test.pdf";
+        public const String GoodPdfUrl = @"https://www.gemini.com/documents/credit/Test_PDF.pdf";
         public const String GoodHtmlUrl = @"http://www.orimi.com/";
         public const String BadHtmlUrl = @"http://www.orimi.com:8888/";
 
         public const String GoodMultipagePdfUrl =
-            @"https://www.ets.org/Media/Tests/GRE/pdf/gre_research_validity_data.pdf";
+            @"https://www.adobe.com/support/products/enterprise/knowledgecenter/media/c4611_sample_explain.pdf";
 
         public const String GoodPdfFile = @"should-work.pdf";
         public const String GoodMultipagePdfFile = @"should-work-multipage.pdf";

--- a/tests/UnitTests/Split/SplitTests.cs
+++ b/tests/UnitTests/Split/SplitTests.cs
@@ -92,20 +92,15 @@ namespace Tests.Split
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void Split_BigFileName_ShouldThrowException()
+        public void Split_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodMultipagePdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/Unlock/UnlockTests.cs
+++ b/tests/UnitTests/Unlock/UnlockTests.cs
@@ -91,20 +91,15 @@ namespace Tests.Unlock
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void Unlock_BigFileName_ShouldThrowException()
+        public void Unlock_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/ValidatePdfA/ValidatePdfATests.cs
+++ b/tests/UnitTests/ValidatePdfA/ValidatePdfATests.cs
@@ -93,20 +93,15 @@ namespace Tests.ValidatePdfA
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void ValidatePdfA_BigFileName_ShouldThrowException()
+        public void ValidatePdfA_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]

--- a/tests/UnitTests/WaterMark/WaterMarkTests.cs
+++ b/tests/UnitTests/WaterMark/WaterMarkTests.cs
@@ -92,20 +92,15 @@ namespace Tests.WaterMark
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ProcessingException),
-            "OutputFileName bigger than allowed was inappropriately processed.")]
-        public void WaterMark_BigFileName_ShouldThrowException()
+        public void WaterMark_BigOutputFileName_ShouldThrowException()
         {
             InitApiWithRightCredentials();
 
             AddFile($"{Guid.NewGuid()}.pdf", Settings.GoodPdfFile);
 
-            var outputFileName = @"";
-            for (var i = 0; i < Settings.MaxCharactersInFilename; i++)
-                outputFileName = $"{outputFileName}a";
-            TaskParams.OutputFileName = $"{outputFileName}.pdf";
+            TaskParams.OutputFileName = Arrange_BigOutputFileName();
 
-            Assert.IsFalse(RunTask());
+            AssertThrowsException_BigOutputFileName(() => RunTask());
         }
 
         [TestMethod]


### PR DESCRIPTION
1. Change the expected exception for all BigOutputFileName tests, from ProcessException to ServerErrorException.
Create a single helper method in order to easily change in the future.
Details:
A server error (500) occurs when a file with a name length of 130 characters is sent. The server was expected to respond with a ProcessException error but it responded with an unspecified error (500).
{
    "error":{
       "type":"ServerError",
       "message":"Something on our end went wrong, probably we are not catching some exception we should catch! We are logging this and we will fix it.",
       "code":"500"
    }
}

2. - Change dead pdf urls on test settings
- Add debug mode
- Change async http post call to sync

3. Change release-preview action trigger
